### PR TITLE
set large skin if width >= 640 pixels to avoid tiny font

### DIFF
--- a/src/frontends/sdl/sdl.c
+++ b/src/frontends/sdl/sdl.c
@@ -1280,7 +1280,11 @@ static void *start_player(void *arg)
 	cfg_add_key_if_not_present(config, "SDL.LyricsFilePattern", "$.txt;*.txt");
 	cfg_add_key_if_not_present(config, "SDL.AutoSelectCurrentPlaylistItem", "no");
 	cfg_key_add_presets(config, "SDL.AutoSelectCurrentPlaylistItem", "yes", "no", NULL);
-	cfg_add_key_if_not_present(config, "SDL.DefaultSkin", "default-modern");
+	if (screen_max_width >= 640) {
+		cfg_add_key_if_not_present(config, "SDL.DefaultSkin", "default-modern-large");
+    } else {
+		cfg_add_key_if_not_present(config, "SDL.DefaultSkin", "default-modern");
+    }
 	cfg_add_key_if_not_present(config, "SDL.Scroll", "always");
 	cfg_key_add_presets(config, "SDL.Scroll", "always", "auto", "never", NULL);
 	cfg_add_key_if_not_present(config, "SDL.BacklightPowerOnOnTrackChange", "no");


### PR DESCRIPTION
Referring to https://github.com/eduardofilo/RG350_adam_image/discussions/241#discussioncomment-2799406 I created a small PR that should pick the fitting skin depending on the screen resolution.

I must admit I did not go thought the hassle of compiling gmu-odbeta to test it, but this change looks very straightforward to me. So forgive me if there is still something not exactly correct, please feel free to correct.

